### PR TITLE
feat: add virtual network subnet ID to flex consumption function app

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,11 +461,11 @@ object({
           virtual_network_subnet_id = optional(string)
           description               = optional(string)
           headers = optional(object({
-          x_azure_fdid      = optional(list(string), [])
-          x_fd_health_probe = optional(list(string), [])
-          x_forwarded_for   = optional(list(string), [])
-          x_forwarded_host  = optional(list(string), [])
-        }), null)
+            x_azure_fdid      = optional(list(string), [])
+            x_fd_health_probe = optional(list(string), [])
+            x_forwarded_for   = optional(list(string), [])
+            x_forwarded_host  = optional(list(string), [])
+          }), null)
         })), {})
         scm_ip_restrictions = optional(map(object({
           action                    = optional(string, "Allow")
@@ -476,11 +476,11 @@ object({
           virtual_network_subnet_id = optional(string)
           description               = optional(string)
           headers = optional(object({
-          x_azure_fdid      = optional(list(string), [])
-          x_fd_health_probe = optional(list(string), [])
-          x_forwarded_for   = optional(list(string), [])
-          x_forwarded_host  = optional(list(string), [])
-        }), null)
+            x_azure_fdid      = optional(list(string), [])
+            x_fd_health_probe = optional(list(string), [])
+            x_forwarded_for   = optional(list(string), [])
+            x_forwarded_host  = optional(list(string), [])
+          }), null)
         })), {})
         application_stack = optional(object({
           dotnet_version              = optional(string)

--- a/main.tf
+++ b/main.tf
@@ -1475,6 +1475,7 @@ resource "azurerm_function_app_flex_consumption" "this" {
   https_only                                     = var.instance.https_only
   enabled                                        = var.instance.enabled
   public_network_access_enabled                  = var.instance.public_network_access_enabled
+  virtual_network_subnet_id                      = var.instance.virtual_network_subnet_id
   client_certificate_enabled                     = var.instance.client_certificate_enabled
   client_certificate_mode                        = var.instance.client_certificate_mode
   client_certificate_exclusion_paths             = var.instance.client_certificate_exclusion_paths

--- a/variables.tf
+++ b/variables.tf
@@ -409,11 +409,11 @@ variable "instance" {
           virtual_network_subnet_id = optional(string)
           description               = optional(string)
           headers = optional(object({
-          x_azure_fdid      = optional(list(string), [])
-          x_fd_health_probe = optional(list(string), [])
-          x_forwarded_for   = optional(list(string), [])
-          x_forwarded_host  = optional(list(string), [])
-        }), null)
+            x_azure_fdid      = optional(list(string), [])
+            x_fd_health_probe = optional(list(string), [])
+            x_forwarded_for   = optional(list(string), [])
+            x_forwarded_host  = optional(list(string), [])
+          }), null)
         })), {})
         scm_ip_restrictions = optional(map(object({
           action                    = optional(string, "Allow")
@@ -424,11 +424,11 @@ variable "instance" {
           virtual_network_subnet_id = optional(string)
           description               = optional(string)
           headers = optional(object({
-          x_azure_fdid      = optional(list(string), [])
-          x_fd_health_probe = optional(list(string), [])
-          x_forwarded_for   = optional(list(string), [])
-          x_forwarded_host  = optional(list(string), [])
-        }), null)
+            x_azure_fdid      = optional(list(string), [])
+            x_fd_health_probe = optional(list(string), [])
+            x_forwarded_for   = optional(list(string), [])
+            x_forwarded_host  = optional(list(string), [])
+          }), null)
         })), {})
         application_stack = optional(object({
           dotnet_version              = optional(string)


### PR DESCRIPTION
## Description

virtual network integration for flex consumption plan

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_function_app_flex_consumption` - support for the `virtual_network_subnet_id ` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #81 
